### PR TITLE
Added support for data samples using the "records" keyword

### DIFF
--- a/src/main/kotlin/nz/co/steelsky/dbmlplugin/highlighting/DbmlColorSettingsPage.kt
+++ b/src/main/kotlin/nz/co/steelsky/dbmlplugin/highlighting/DbmlColorSettingsPage.kt
@@ -45,6 +45,10 @@ Table users as U [headercolor: #3498db] {
     (name, email) [unique, name: 'idx_name_email']
   }
 
+  records (id, name, email) {
+    0, 'user, 'user@example.com'
+  }
+  
   Note: '''
     Stores user accounts
     Escape demo: it\'s working

--- a/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/Dbml.flex
+++ b/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/Dbml.flex
@@ -91,6 +91,7 @@ COLOR_CODE_BODY = {HEX_DIGIT}{6} | {HEX_DIGIT}{3}
     [Pp][Rr][Oo][Jj][Ee][Cc][Tt]                                { return PROJECT; }
     [Pp][Rr][Ii][Mm][Aa][Rr][Yy]                                { return PRIMARY; }
     [Ii][Nn][Dd][Ee][Xx][Ee][Ss]                                { return INDEXES; }
+    [Rr][Ee][Cc][Oo][Rr][Dd][Ss]                                { return RECORDS; }
     [Uu][Nn][Ii][Qq][Uu][Ee]                                    { return UNIQUE; }
     [Dd][Ee][Ll][Ee][Tt][Ee]                                    { return DELETE; }
     [Uu][Pp][Dd][Aa][Tt][Ee]                                    { return UPDATE; }

--- a/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/DbmlTokenSets.kt
+++ b/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/DbmlTokenSets.kt
@@ -19,7 +19,7 @@ object DbmlTokenSets {
     @JvmField
     val KEYWORDS = TokenSet.create(
         DbmlTypes.PROJECT, DbmlTypes.TABLE, DbmlTypes.AS,
-        DbmlTypes.REF, DbmlTypes.ENUM, DbmlTypes.TABLEGROUP,
+        DbmlTypes.REF, DbmlTypes.ENUM, DbmlTypes.RECORDS, DbmlTypes.TABLEGROUP,
         DbmlTypes.TABLEPARTIAL, DbmlTypes.HEADERCOLOR, DbmlTypes.COLOR,
         DbmlTypes.NOTE, DbmlTypes.PRIMARY, DbmlTypes.KEY,
         DbmlTypes.PK, DbmlTypes.NULL, DbmlTypes.NOT,

--- a/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/DbmlTokenType.kt
+++ b/src/main/kotlin/nz/co/steelsky/dbmlplugin/lexer/DbmlTokenType.kt
@@ -44,6 +44,7 @@ class DbmlTokenType(debugName: String) : IElementType(debugName, DbmlLanguage) {
             "AS" to "'as'",
             "REF" to "'Ref'",
             "ENUM" to "'Enum'",
+            "RECORDS" to "'Records'",
             "TABLEGROUP" to "'TableGroup'",
             "TABLEPARTIAL" to "'TablePartial'",
             "HEADERCOLOR" to "'headercolor'",

--- a/src/main/kotlin/nz/co/steelsky/dbmlplugin/parser/Dbml.bnf
+++ b/src/main/kotlin/nz/co/steelsky/dbmlplugin/parser/Dbml.bnf
@@ -12,6 +12,7 @@
   tokens = [
     PROJECT="PROJECT"
     TABLE="TABLE"
+    RECORDS="RECORDS"
     AS="AS"
     REF="REF"
     ENUM="ENUM"
@@ -73,9 +74,9 @@
 // Root — NEWLINE is NOT auto-skipped, so it must appear explicitly in the grammar.
 dbmlFile ::= (item_ | NEWLINE)*
 private item_ ::= (project_definition | table_definition | ref_definition | enum_definition
-                   | table_group | table_partial | named_note)
+                   | table_group | table_partial | named_note | records_definition)
                    {recoverWhile=item_recover_}
-private item_recover_ ::= !(PROJECT | TABLE | REF | ENUM | TABLEGROUP | TABLEPARTIAL | NOTE | NEWLINE | <<eof>>)
+private item_recover_ ::= !(PROJECT | TABLE | REF | ENUM | TABLEGROUP | TABLEPARTIAL | NOTE | RECORDS | NEWLINE | <<eof>>)
 
 // === Shared rules ===
 // Many keywords can appear as identifiers (column names, table names, etc.) in DBML.
@@ -104,7 +105,7 @@ table_settings ::= LBRACK table_setting (COMMA table_setting)* RBRACK {pin=1}
 table_setting ::= HEADERCOLOR COLON COLOR_CODE | NOTE COLON string_literal_
 // Order matters: indexes_definition, table_note, and table_partial_ref must be tried
 // BEFORE column_definition, because identifier_ now matches keywords like NOTE, INDEXES, etc.
-private table_body ::= (indexes_definition | table_note | table_partial_ref | column_definition | nl_)*
+private table_body ::= (indexes_definition | table_note | table_partial_ref | table_records | column_definition | nl_)*
 private table_note ::= NOTE note_value
 table_partial_ref ::= TILDE identifier_
 
@@ -185,3 +186,12 @@ named_note ::= NOTE identifier_ LBRACE string_literal_ RBRACE {pin=1}
 
 // === Note (shared) ===
 note_value ::= COLON string_literal_ | LBRACE string_literal_ RBRACE
+
+// === Records ===
+records_definition ::= RECORDS table_name records_config {pin=1}
+table_records ::= RECORDS records_config {pin=1}
+private records_config ::= (LPAREN records_column_list RPAREN)? LBRACE records_body RBRACE
+private records_column_list ::= identifier_ (COMMA identifier_)*
+private records_body ::= (records_row | nl_)*
+records_row ::= records_value (COMMA records_value?)* {pin=1}
+records_value ::= MINUS NUMBER | string_literal_ | NUMBER | EXPRESSION | NULL | identifier_ (DOT identifier_)*

--- a/src/test/kotlin/nz/co/steelsky/dbmlplugin/parser/DbmlParserTest.kt
+++ b/src/test/kotlin/nz/co/steelsky/dbmlplugin/parser/DbmlParserTest.kt
@@ -40,6 +40,10 @@ class DbmlParserTest : ParsingTestCase("", "dbml", DbmlParserDefinition()) {
         doTest(true)
     }
 
+    fun testRecords() {
+        doTest(true)
+    }
+
     override fun getTestDataPath(): String = "src/test/testData/parser"
     override fun skipSpaces(): Boolean = false
     override fun includeRanges(): Boolean = true

--- a/src/test/testData/parser/Records.dbml
+++ b/src/test/testData/parser/Records.dbml
@@ -1,0 +1,35 @@
+// Outside table definition
+Table users {
+  id int [pk]
+  name varchar
+  email varchar
+}
+
+records users(id, name, email) {
+  1, 'Alice', 'alice@example.com'
+  2, 'Bob', 'bob@example.com'
+}
+
+// Inside table definition with explicit column list
+Table posts {
+  id int [pk]
+  title varchar
+  published boolean
+
+  records (id, title, published) {
+    1, 'First Post', true
+    2, 'Second Post', false
+  }
+}
+
+// Inside table definition with implicit column list
+Table comments {
+  id int [pk]
+  user_id int [ref: > users.id]
+  post_id int [ref: > posts.id]
+  title string
+
+  records {
+    1, 2, 1, 'First comment of first post by the second user'
+  }
+}


### PR DESCRIPTION
Hi,

This PR adds support for data samples : https://dbml.dbdiagram.io/docs#data-sample
> `Records` allows you to define sample data for your tables directly in DBML. This is useful for documentation, testing, and providing example data for your database schema.

For some reason, my environment refuses to start tests, but I can successfully build it and use it inside the IDE:
<img width="377" height="208" alt="image" src="https://github.com/user-attachments/assets/d2719c94-5450-42a7-b1f4-43ad1a1f3f3c" />

Note that this change only provides the base syntax part, it does not check that columns actually exist or that the number of elements in `records_column_list` matches the number of elements in `records_row`